### PR TITLE
ISSUE-9: Extend fields' truncation size in accesstokens' index

### DIFF
--- a/src/migrations/01_enlargeSizeOfAccesstokensUniqueIndex.js
+++ b/src/migrations/01_enlargeSizeOfAccesstokensUniqueIndex.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const up = async ({ context: queryInterface }) => {
+  try {
+    await queryInterface.removeIndex(
+      'accesstokens',
+      'accesstokens_platform_url_client_id_scopes'
+    )
+
+    await queryInterface.addIndex(
+      'accesstokens',
+      [
+        { name: 'platformUrl', length: 255 },
+        { name: 'clientId', length: 255 },
+        { name: 'scopes', length: 255 }
+      ],
+      {
+        name: 'accesstokens_platform_url_client_id_scopes',
+        unique: true
+      }
+    )
+  } catch (err) {
+    console.error('Database migration failed', err)
+  }
+}
+
+const down = async ({ context: queryInterface }) => {
+  await queryInterface.removeIndex(
+    'accesstokens',
+    'accesstokens_platform_url_client_id_scopes'
+  )
+
+  await queryInterface.addIndex(
+    'accesstokens',
+    [
+      { name: 'platformUrl', length: 50 },
+      { name: 'clientId', length: 50 },
+      { name: 'scopes', length: 50 }
+    ],
+    {
+      name: 'accesstokens_platform_url_client_id_scopes',
+      unique: true
+    }
+  )
+}
+
+module.exports = { up, down }


### PR DESCRIPTION
To fix short-index collision the size of field values were enlarged from 50 to 255.
It is not clear what is the possible maximum size of used fields (platformUrl, clientId, scopes). The most problematic one is 'scopes' as it is a list of string values.